### PR TITLE
Fixed csrfToken-getter

### DIFF
--- a/holehe/modules/cms/atlassian.py
+++ b/holehe/modules/cms/atlassian.py
@@ -20,7 +20,7 @@ async def atlassian(email, client, out):
     }
     try:
         r = await client.get("https://id.atlassian.com/login", headers=headers)
-        data = {'csrfToken': r.text.split('{&quot;csrfToken&quot;:&quot;')[
+        data = {'csrfToken': r.text.split(',&quot;csrfToken&quot;:&quot;')[
             1].split('&quot')[0], 'username': email}
     except Exception:
         out.append({"name": name,"domain":domain,"method":method,"frequent_rate_limit":frequent_rate_limit,


### PR DESCRIPTION
Line 23 of `/holehe/blob/master/holehe/modules/cms/atlassian.py` was basically the error. I have replaced `r.text.split({,&quot;csrfToken&quot;:&quot;')` with `r.text.split(',&quot;csrfToken&quot;:&quot;')`, as it was probably changed in https://id.atlassian.com/login after the release of this repo. With that code changed it should return the correct account information every time.

TL;DR: Fixed the splitting of text output, returned error every time.